### PR TITLE
refactor: replace eval() with plain dict in custom_strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,34 +117,42 @@ if you end up using custom strings, you might want `no_extra` words/ formatting,
 change word formatting in formats.py
 
 ### custom flag
-default `custom_flag = cusz`
+default `custom_flag = var`
 
 change flag in grammar.py
 
 ### horizontal fill
 if horizontal fill, `change_axis = False`
 ```
-cusz_0 = ["foo", "baz"]
-if prompt_format = "cusz_0-bar-cusz_0"
-then prompt = ["foo", "bar", "baz"]
+if prompt_format = "var_0-bar-var_0"
+then prompt = ["foo", "bar", "baz"]   # pulls from var_0 = ["foo", "baz"] by position
 ```
 change axis in grammar.py
 
 ### vertical fill
 if vertical fill, `change_axis = True`
 ```
-cusz_colors = ["red", "blue"]
-cusz_animal = ["zebra", "horse"]
-if prompt_format = "cusz_colors-cusz_animal"
-then prompt = ["red", "horse"]
+if prompt_format = "var_color-var_animal"
+then prompt = ["red", "horse"]        # samples independently from each named list
 ```
 change axis in grammar.py
 
 ## custom_strings.py
-declare custom strings here
+declare custom strings in the `custom_strings` dict:
+```python
+custom_strings = {
+    "var_0":     ["foo", "baz"],
+    "var_color": ["red", "blue"],
+}
 ```
-<custom_flag>_listOfStrings = ["foo", "bar"]
-```
+
+naming rules (validated at import time):
+* keys must start with `<custom_flag>_` (default: `var_`)
+* only one underscore — use camelCase for multi-word names: `var_myList`
+* values must be non-empty lists
+
+the file also exports `custom_all_strings` — a count-indexed view of the same data used
+internally by `generator.py` to match unsubscripted `cusz` tokens to lists of the right length.
 
 ## formats.py
 unfortunately not a class 

--- a/prompts/custom_strings.py
+++ b/prompts/custom_strings.py
@@ -1,58 +1,60 @@
 from .grammar import custom_flag
-#####################################################################
-# horizontal fill
-# change_axis == False
-#
-# "cusz_0-year_nf-form_nf-cusz_0" will check for cus_0, and greedily inject from cus_0
-# a photo of a 1700 painting in 8K ULTRA HD
-#
-# `cusz` without additional specification
-#
-# "cusz-year_nf-form_nf" will check for any cus_x, where len(cus_x) == number of custom flags found in format
-# format.count(custom_flag) == 1, so cus_1a OR cus_1b 
-# a zipped file of a 1700 painting OR the non-compressed version of a 1700 painting
-# 
-#####################################################################
-# vertical fill
-# change_axis == True
-#
-# "year_nf-cus_colors-form_nf-cus_types" will sample and inject from cus_colors and cus_4 accordingly
-# 1700 blue painting BDR
-#
-# `cusz` not allowed
-#####################################################################
-
-# avoid using <custom_flag> in list name
-# should follow <custom_flag>_listOfStrings 
-cusz_0 = ["a photo of a", "in 8K ULTRA HD"]
-cusz_1a = ["a zipped file of a"]
-cusz_1b = ["the non-compressed version of a"]
-cusz_color = ["red", "blue"]
-cusz_type = ["BDR", "WEB-DL", "CAM-Rip"]
-
-
 
 #####################################################################
-custom_all_strings = {} # if renaming, update generator.py > parse_format() as well
-for name in dir():
-    if not name.startswith('__'):
-        actual = eval(name)
-        if type(actual) is list:
-            if name == custom_flag:
-                raise Exception("list name == custom flag not allowed")
-            elif not "_" in name:
-                raise Exception(f"{name} not allowed, please follow list naming convention")
-            elif not f"{custom_flag}_" in name:
-                raise Exception(f"{name} not allowed, please start list name with `{custom_flag}_`")
-            elif name.count("_") > 1:
-                raise Exception(f"{name} not allowed, use camelCase instead")
-            elif name.count(custom_flag) > 1:
-                raise Exception(f"{name} not allowed, avoid using flag in list name")
-            length = len(actual)
-            if length == 0:
-                raise Exception(f"{name} is empty")
-            if length in custom_all_strings:
-                custom_all_strings[length].append(actual)
-            else:
-                custom_all_strings[length] = [actual]
+# Add custom string lists to the dict below.
+# Each key must follow the pattern  <custom_flag>_listName  (e.g. "var_0").
+# Use camelCase for multi-word names: "var_myList", not "var_my_list".
+#
+# horizontal fill  (change_axis = False in grammar.py)
+#
+#   "var_0-year_nf-form_nf-var_0"
+#   → greedily pulls from var_0 by position
+#   → "a photo of a 1700 painting in 8K ULTRA HD"
+#
+#   "var-year_nf-form_nf"
+#   → picks any list whose length equals the number of var tokens (1 here)
+#   → "a zipped file of a 1700 painting"  OR
+#      "the non-compressed version of a 1700 painting"
+#
+# vertical fill  (change_axis = True in grammar.py)
+#
+#   "year_nf-var_color-form_nf-var_type"
+#   → samples one entry from each named list independently
+#   → "1700 blue painting BDR"
+#   (unsubscripted `var` is not allowed in vertical mode)
+#####################################################################
 
+custom_strings: dict[str, list[str]] = {
+    "var_0":     ["a photo of a", "in 8K ULTRA HD"],
+    "var_1a":    ["a zipped file of a"],
+    "var_1b":    ["the non-compressed version of a"],
+    "var_color": ["red", "blue"],
+    "var_type":  ["BDR", "WEB-DL", "CAM-Rip"],
+}
+
+#####################################################################
+# Validation — checked once at import time.
+#####################################################################
+for _name, _strings in custom_strings.items():
+    if _name == custom_flag:
+        raise ValueError(f"list name cannot equal the custom flag '{custom_flag}'")
+    if "_" not in _name:
+        raise ValueError(f"'{_name}' must follow naming convention: {custom_flag}_listName")
+    if not _name.startswith(f"{custom_flag}_"):
+        raise ValueError(f"'{_name}' must start with '{custom_flag}_'")
+    if _name.count("_") > 1:
+        raise ValueError(f"'{_name}' has too many underscores — use camelCase after the prefix (e.g. {custom_flag}_myList)")
+    if _name.count(custom_flag) > 1:
+        raise ValueError(f"'{_name}' — avoid repeating the flag in the list name")
+    if len(_strings) == 0:
+        raise ValueError(f"'{_name}' is empty")
+
+#####################################################################
+# Build the count-indexed lookup used by generator.py when the
+# prompt format contains an unsubscripted var token.
+# Maps  list_length → [list, list, ...]  so the caller can pick any
+# list whose length matches the number of var slots in the format.
+#####################################################################
+custom_all_strings: dict[int, list[list[str]]] = {}
+for _strings in custom_strings.values():
+    custom_all_strings.setdefault(len(_strings), []).append(_strings)

--- a/prompts/formats.py
+++ b/prompts/formats.py
@@ -31,15 +31,15 @@ def get_custom_format(counter, f, data, prompt_format):
             # randomized data
             text = get_custom_horizontal(counter, data)
         else:
-            # get list from grammar.py
-            custom = eval(f)
+            # look up list by name from custom_strings dict
+            custom = custom_strings[f]
             if change_axis:
                 text = get_custom_vertical(custom)
             else:
                 text = get_custom_horizontal(counter, custom)
                 if text is None:
                     raise Exception(f"{f} has {len(custom)} value(s) but you specified at least {counter+1} flags in {prompt_format}")
-    except NameError as e:
+    except KeyError:
         raise Exception(f"{f} not in custom_strings.py")
     
     formatting = f

--- a/prompts/grammar.py
+++ b/prompts/grammar.py
@@ -18,9 +18,9 @@ valid_grammar = [
     "school_nf-type_nf-form_nf-author_pf", # german mythological painting by zwirner
     "school_nf-type_nf-form_nf-author_pf-year_af", # german mythological painting by zwirner (1839)
     "school_nf-type_nf-form_nf-author_pf-year_af-bd_nf", # german mythological painting by zwirner (b. 1802, Jakobswalde, d. 1861, Köln)
-    # # "any_nf", # any one 
-    # "school_nf-cusz_color-type_nf-form_nf-author_pf-year_af-cusz_type", 
-    "cusz_0-year_nf-form_nf-cusz_0" # a photo of a 1700 painting in 8K ULTRA HD 
+    # # "any_nf", # any one
+    # "school_nf-var_color-type_nf-form_nf-author_pf-year_af-var_type",
+    "var_0-year_nf-form_nf-var_0" # a photo of a 1700 painting in 8K ULTRA HD
 ]
 
 # extra stuff to possibly attach to valid grammar
@@ -34,8 +34,8 @@ extra = ["year_af", "location_pf"]
 
 #########################################
 # check custom_strings.py for examples
-custom_flag = "cusz"
-# use cus_x when writing valid grammar to specify a list
+custom_flag = "var"
+# use var_x when writing valid grammar to specify a list
 
 # check custom_strings.py for examples
 change_axis = False


### PR DESCRIPTION
## Summary
- Replaces module-level `cusz_*` variable declarations + `dir()` + `eval()` introspection with a plain `custom_strings` dict in `custom_strings.py`
- Swaps `eval(f)` in `formats.py` for a direct `custom_strings[f]` dict lookup
- Renames default `custom_flag` from `cusz` to `var`
- Updates README and inline comments to match

Closes #10

## Test plan
- [ ] Verify `from prompts.custom_strings import custom_strings, custom_all_strings` works as expected
- [ ] Confirm `custom_all_strings` count-indexed structure is identical to before
- [ ] Run `get_prompt_format()` and `parse_format()` end-to-end with existing grammar entries
- [ ] Add a new entry to `custom_strings` dict and confirm it's picked up without code changes
- [ ] Confirm validation errors fire correctly (empty list, bad prefix, duplicate flag in name)